### PR TITLE
API paths in double quotes in CURL window.

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -1346,7 +1346,7 @@
       entries.push("-d '" + JSON.stringify(JSON.parse(this.params.body)) + "'") ;
     }
 
-    return "curl " + (entries.join(" ")) + " " + this.url;
+    return "curl " + (entries.join(" ")) + " \"" + this.url + "\"";
   };
 
   /**


### PR DESCRIPTION
Required fix for https://github.com/auth0/swagger-docs/issues/88